### PR TITLE
Allow ActiveSupport versions above 3.2

### DIFF
--- a/rxsd.gemspec
+++ b/rxsd.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.3")
 
   s.add_dependency('libxml-ruby', '~> 2.4.0')
-  s.add_dependency('activesupport', '~> 3.2.11')
+  s.add_dependency('activesupport', '> 3.2')
   s.add_development_dependency('rspec', '~> 2.12.0')
 
   s.author = "Mo Morsi"


### PR DESCRIPTION
I am attempting to use RXSD in a Rails 4.1 application. I get this from bundler:

```
Resolving dependencies...
Bundler could not find compatible versions for gem "activesupport":
  In snapshot (Gemfile.lock):
    activesupport (4.1.4)

  In Gemfile:
    rxsd (>= 0) ruby depends on
      activesupport (~> 3.2.11) ruby
```

ActiveSupport is used in https://github.com/movitto/RXSD/blob/454efb1f20d095d54186add9c90c25810ecebf12/lib/rxsd/common.rb#L7 

ActiveSupport 4.1.4 might work just fine:

```
irb(main):001:0> require 'active_support/inflector'
=> true
irb(main):002:0> ActiveSupport::Inflector
=> ActiveSupport::Inflector
irb(main):003:0> require 'active_support/version'
=> true
irb(main):004:0> ActiveSupport::VERSION::STRING
=> "4.1.4"
```
